### PR TITLE
:hammer: chore: build post yarn install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install project dependencies
-        run: yarn --prefer-offline
+        run: yarn ci
        
       - run: yarn lint
         name: Linting

--- a/package.json
+++ b/package.json
@@ -49,8 +49,9 @@
     "prebuild": "rimraf ./packages/react-move-hook/lib",
     "build": "rollup -c rollup.config.js",
     "watch": "rollup -w -c rollup.config.js",
-    "ci": "yarn install --frozen-lockfile",
-    "lint": "yarn eslint --max-warnings=0 --ext .js,.jsx,.ts,.tsx ./"
+    "ci": "yarn install --frozen-lockfile --ignore-scripts --prefer-offline",
+    "lint": "yarn eslint --max-warnings=0 --ext .js,.jsx,.ts,.tsx ./",
+    "postinstall": "yarn build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Calling `build` task after installation to make sure examples work immediately.

- Created separate CI installation task that doesn't trigger rebuild after installation.